### PR TITLE
Ensure functions are type consistent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 * `str_remove()` and `str_remove_all()` have been refactored to no longer rely on `str_replace()` and `str_replace_all()`. This improves their portability.
 * `str_subset()` has been refactored to no longer rely on `str_which()`. This improves its portability.
 * All `stringstatic` functions are now exported. They can be run interactively by loading the `stringstatic` package. Using `staticimports` remains the recommended way to use `stringstatic` functions in your own package.
+* All `stringstatic` functions are now type consistent. Previously, functions may have returned different types for zero-length inputs than for non-zero-length inputs.
 
 ## Bug fixes
 * Fixed a bug where `fixed(ignore_case = TRUE)` would not actually ignore case.

--- a/R/str_count.R
+++ b/R/str_count.R
@@ -24,7 +24,8 @@
 
 str_count <- function(string, pattern = "") {
 	is_fixed <- inherits(pattern, "stringr_fixed")
-	mapply(
+
+	count <- mapply(
 		function(string, pattern) {
 			match <- unlist(
 				gregexpr(pattern, text = string, perl = !is_fixed, fixed = is_fixed)
@@ -33,4 +34,7 @@ str_count <- function(string, pattern = "") {
 		},
 		string, pattern, SIMPLIFY = "vector", USE.NAMES = FALSE
 	)
+
+	mode(count) <- "integer"
+	count
 }

--- a/R/str_remove.R
+++ b/R/str_remove.R
@@ -24,9 +24,13 @@
 
 str_remove <- function(string, pattern) {
 	is_fixed <- inherits(pattern, "stringr_fixed")
-	Vectorize(sub, c("pattern", "x"), USE.NAMES = FALSE)(
+
+	string <- Vectorize(sub, c("pattern", "x"), USE.NAMES = FALSE)(
 		pattern, replacement = "", x = string, perl = !is_fixed, fixed = is_fixed
 	)
+
+	mode(string) <- "character"
+	string
 }
 
 #' Remove matched patterns in a string
@@ -52,7 +56,11 @@ str_remove <- function(string, pattern) {
 
 str_remove_all <- function(string, pattern) {
 	is_fixed <- inherits(pattern, "stringr_fixed")
-	Vectorize(gsub, c("pattern", "x"), USE.NAMES = FALSE)(
+
+	string <- Vectorize(gsub, c("pattern", "x"), USE.NAMES = FALSE)(
 		pattern, replacement = "", x = string, perl = !is_fixed, fixed = is_fixed
 	)
+
+	mode(string) <- "character"
+	string
 }

--- a/R/str_replace.R
+++ b/R/str_replace.R
@@ -36,9 +36,13 @@
 
 str_replace <- function(string, pattern, replacement) {
 	is_fixed <- inherits(pattern, "stringr_fixed")
-	Vectorize(sub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
+
+	string <- Vectorize(sub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
 		pattern, replacement, x = string, perl = !is_fixed, fixed = is_fixed
 	)
+
+	mode(string) <- "character"
+	string
 }
 
 #' Replace matched patterns in a string
@@ -88,13 +92,15 @@ str_replace_all <- function(string, pattern, replacement) {
 				fixed = is_fixed
 			)
 		}
-
 		return(string)
 	}
 
-	Vectorize(gsub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
+	string <- Vectorize(gsub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
 		pattern, replacement, x = string, perl = !is_fixed, fixed = is_fixed
 	)
+
+	mode(string) <- "character"
+	string
 }
 
 #' Turn NA into "NA"

--- a/inst/staticexports/str_count.R
+++ b/inst/staticexports/str_count.R
@@ -21,7 +21,8 @@
 
 str_count <- function(string, pattern = "") {
 	is_fixed <- inherits(pattern, "stringr_fixed")
-	mapply(
+
+	count <- mapply(
 		function(string, pattern) {
 			match <- unlist(
 				gregexpr(pattern, text = string, perl = !is_fixed, fixed = is_fixed)
@@ -30,4 +31,7 @@ str_count <- function(string, pattern = "") {
 		},
 		string, pattern, SIMPLIFY = "vector", USE.NAMES = FALSE
 	)
+
+	mode(count) <- "integer"
+	count
 }

--- a/inst/staticexports/str_remove.R
+++ b/inst/staticexports/str_remove.R
@@ -21,9 +21,13 @@
 
 str_remove <- function(string, pattern) {
 	is_fixed <- inherits(pattern, "stringr_fixed")
-	Vectorize(sub, c("pattern", "x"), USE.NAMES = FALSE)(
+
+	string <- Vectorize(sub, c("pattern", "x"), USE.NAMES = FALSE)(
 		pattern, replacement = "", x = string, perl = !is_fixed, fixed = is_fixed
 	)
+
+	mode(string) <- "character"
+	string
 }
 
 #' Remove matched patterns in a string
@@ -49,7 +53,11 @@ str_remove <- function(string, pattern) {
 
 str_remove_all <- function(string, pattern) {
 	is_fixed <- inherits(pattern, "stringr_fixed")
-	Vectorize(gsub, c("pattern", "x"), USE.NAMES = FALSE)(
+
+	string <- Vectorize(gsub, c("pattern", "x"), USE.NAMES = FALSE)(
 		pattern, replacement = "", x = string, perl = !is_fixed, fixed = is_fixed
 	)
+
+	mode(string) <- "character"
+	string
 }

--- a/inst/staticexports/str_replace.R
+++ b/inst/staticexports/str_replace.R
@@ -33,9 +33,13 @@
 
 str_replace <- function(string, pattern, replacement) {
 	is_fixed <- inherits(pattern, "stringr_fixed")
-	Vectorize(sub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
+
+	string <- Vectorize(sub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
 		pattern, replacement, x = string, perl = !is_fixed, fixed = is_fixed
 	)
+
+	mode(string) <- "character"
+	string
 }
 
 #' Replace matched patterns in a string
@@ -85,13 +89,15 @@ str_replace_all <- function(string, pattern, replacement) {
 				fixed = is_fixed
 			)
 		}
-
 		return(string)
 	}
 
-	Vectorize(gsub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
+	string <- Vectorize(gsub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
 		pattern, replacement, x = string, perl = !is_fixed, fixed = is_fixed
 	)
+
+	mode(string) <- "character"
+	string
 }
 
 #' Turn NA into "NA"

--- a/tests/testthat/test-str_c.R
+++ b/tests/testthat/test-str_c.R
@@ -1,3 +1,7 @@
+test_that("output is always character", {
+	expect_equal(str_c(), character(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_count.R
+++ b/tests/testthat/test-str_count.R
@@ -1,3 +1,7 @@
+test_that("output is always integer", {
+	expect_equal(str_count(character(0)), integer(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_count.R
+++ b/tests/testthat/test-str_count.R
@@ -1,5 +1,5 @@
 test_that("output is always integer", {
-	expect_equal(str_count(character(0)), integer(0))
+	expect_equal(str_count(character(0), character(0)), integer(0))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_detect.R
+++ b/tests/testthat/test-str_detect.R
@@ -1,7 +1,7 @@
 test_that("output is always logical", {
-	expect_equal(str_detect(character(0), ""), logical(0))
-	expect_equal(str_starts(character(0), ""), logical(0))
-	expect_equal(str_ends(character(0), ""), logical(0))
+	expect_equal(str_detect(character(0), character(0)), logical(0))
+	expect_equal(str_starts(character(0), character(0)), logical(0))
+	expect_equal(str_ends(character(0), character(0)), logical(0))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_detect.R
+++ b/tests/testthat/test-str_detect.R
@@ -1,3 +1,9 @@
+test_that("output is always logical", {
+	expect_equal(str_detect(character(0), ""), logical(0))
+	expect_equal(str_starts(character(0), ""), logical(0))
+	expect_equal(str_ends(character(0), ""), logical(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_dup.R
+++ b/tests/testthat/test-str_dup.R
@@ -1,3 +1,7 @@
+test_that("output is always character", {
+	expect_equal(str_dup(character(0), 0), character(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_extract.R
+++ b/tests/testthat/test-str_extract.R
@@ -1,3 +1,8 @@
+test_that("output is always character", {
+	expect_equal(str_extract(character(0), 0), character(0))
+	expect_equal(str_extract_all(character(0), 0), list())
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_extract.R
+++ b/tests/testthat/test-str_extract.R
@@ -1,6 +1,9 @@
 test_that("output is always character", {
-	expect_equal(str_extract(character(0), 0), character(0))
-	expect_equal(str_extract_all(character(0), 0), list())
+	expect_equal(str_extract(character(0), character(0)), character(0))
+})
+
+test_that("output is always a list", {
+	expect_equal(str_extract_all(character(0), character(0)), list())
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_length.R
+++ b/tests/testthat/test-str_length.R
@@ -1,3 +1,8 @@
+test_that("output is always integer", {
+	expect_equal(str_length(character(0)), integer(0))
+	expect_equal(str_width(character(0)), integer(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_match.R
+++ b/tests/testthat/test-str_match.R
@@ -1,5 +1,5 @@
 test_that("output is always character", {
-	expect_equal(str_match(character(0), ""), matrix(character(0)))
+	expect_equal(str_match(character(0), character(0)), matrix(character(0)))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_match.R
+++ b/tests/testthat/test-str_match.R
@@ -1,3 +1,7 @@
+test_that("output is always character", {
+	expect_equal(str_match(character(0), ""), matrix(character(0)))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_pad.R
+++ b/tests/testthat/test-str_pad.R
@@ -1,3 +1,7 @@
+test_that("output is always character", {
+	expect_equal(str_pad(character(0), 0), character(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_remove.R
+++ b/tests/testthat/test-str_remove.R
@@ -1,3 +1,8 @@
+test_that("output is always character", {
+	expect_equal(str_remove(character(0), ""), character(0))
+	expect_equal(str_remove_all(character(0), ""), character(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_remove.R
+++ b/tests/testthat/test-str_remove.R
@@ -1,6 +1,6 @@
 test_that("output is always character", {
-	expect_equal(str_remove(character(0), ""), character(0))
-	expect_equal(str_remove_all(character(0), ""), character(0))
+	expect_equal(str_remove(character(0), character(0)), character(0))
+	expect_equal(str_remove_all(character(0), character(0)), character(0))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_replace.R
+++ b/tests/testthat/test-str_replace.R
@@ -1,7 +1,16 @@
 test_that("output is always character", {
-	expect_equal(str_replace(character(0), "", ""), character(0))
-	expect_equal(str_replace_all(character(0), "", ""), character(0))
-	expect_equal(str_replace_na(character(0), ""), character(0))
+	expect_equal(
+		str_replace(character(0), character(0), character(0)),
+		character(0)
+	)
+	expect_equal(
+		str_replace_all(character(0), character(0), character(0)),
+		character(0)
+	)
+	expect_equal(
+		str_replace_na(character(0), character(0)),
+		character(0)
+	)
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_replace.R
+++ b/tests/testthat/test-str_replace.R
@@ -1,3 +1,9 @@
+test_that("output is always character", {
+	expect_equal(str_replace(character(0), "", ""), character(0))
+	expect_equal(str_replace_all(character(0), "", ""), character(0))
+	expect_equal(str_replace_na(character(0), ""), character(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_split.R
+++ b/tests/testthat/test-str_split.R
@@ -1,3 +1,11 @@
+test_that("output is always a list", {
+	expect_equal(str_split(character(0), ""), list())
+})
+
+test_that("output is always a character matrix", {
+	expect_equal(str_split_fixed(character(0), "", 1), matrix(character(0)))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_split.R
+++ b/tests/testthat/test-str_split.R
@@ -1,9 +1,12 @@
 test_that("output is always a list", {
-	expect_equal(str_split(character(0), ""), list())
+	expect_equal(str_split(character(0), character(0)), list())
 })
 
 test_that("output is always a character matrix", {
-	expect_equal(str_split_fixed(character(0), "", 1), matrix(character(0)))
+	expect_equal(
+		str_split_fixed(character(0), character(0), 1),
+		matrix(character(0))
+	)
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_subset.R
+++ b/tests/testthat/test-str_subset.R
@@ -1,3 +1,11 @@
+test_that("output is always character", {
+	expect_equal(str_subset(character(0), ""), character(0))
+})
+
+test_that("output is always integer", {
+	expect_equal(str_which(character(0), ""), integer(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #

--- a/tests/testthat/test-str_subset.R
+++ b/tests/testthat/test-str_subset.R
@@ -1,9 +1,9 @@
 test_that("output is always character", {
-	expect_equal(str_subset(character(0), ""), character(0))
+	expect_equal(str_subset(character(0), character(0)), character(0))
 })
 
 test_that("output is always integer", {
-	expect_equal(str_which(character(0), ""), integer(0))
+	expect_equal(str_which(character(0), character(0)), integer(0))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_trim.R
+++ b/tests/testthat/test-str_trim.R
@@ -1,3 +1,8 @@
+test_that("output is always character", {
+	expect_equal(str_trim(character(0)), character(0))
+	expect_equal(str_squish(character(0)), character(0))
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #


### PR DESCRIPTION
Previously, functions may have returned different types for zero-length inputs than for non-zero-length inputs.

Closes #11 