### PR TITLE
Use early returns for zero-length inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,9 +23,9 @@
 * `str_remove()` and `str_remove_all()` have been refactored to no longer rely on `str_replace()` and `str_replace_all()`. This improves their portability.
 * `str_subset()` has been refactored to no longer rely on `str_which()`. This improves its portability.
 * All `stringstatic` functions are now exported. They can be run interactively by loading the `stringstatic` package. Using `staticimports` remains the recommended way to use `stringstatic` functions in your own package.
-* All `stringstatic` functions are now type consistent. Previously, functions may have returned different types for zero-length inputs than for non-zero-length inputs.
 
 ## Bug fixes
+* All `stringstatic` functions are now type consistent. Previously, functions may have returned different types for zero-length inputs than for non-zero-length inputs.
 * Fixed a bug where `fixed(ignore_case = TRUE)` would not actually ignore case.
 
 # stringstatic 0.0.2

--- a/R/str_count.R
+++ b/R/str_count.R
@@ -21,9 +21,9 @@
 #' @staticexport
 
 str_count <- function(string, pattern = "") {
+	if (length(string) == 0 || length(pattern) == 0) return(integer(0))
 	is_fixed <- inherits(pattern, "stringr_fixed")
-
-	count <- mapply(
+	mapply(
 		function(string, pattern) {
 			match <- unlist(
 				gregexpr(pattern, text = string, perl = !is_fixed, fixed = is_fixed)
@@ -32,7 +32,4 @@ str_count <- function(string, pattern = "") {
 		},
 		string, pattern, SIMPLIFY = "vector", USE.NAMES = FALSE
 	)
-
-	mode(count) <- "integer"
-	count
 }

--- a/R/str_remove.R
+++ b/R/str_remove.R
@@ -21,14 +21,11 @@
 #' @staticexport
 
 str_remove <- function(string, pattern) {
+	if (length(string) == 0 || length(pattern) == 0) return(character(0))
 	is_fixed <- inherits(pattern, "stringr_fixed")
-
-	string <- Vectorize(sub, c("pattern", "x"), USE.NAMES = FALSE)(
+	Vectorize(sub, c("pattern", "x"), USE.NAMES = FALSE)(
 		pattern, replacement = "", x = string, perl = !is_fixed, fixed = is_fixed
 	)
-
-	mode(string) <- "character"
-	string
 }
 
 #' Remove matched patterns in a string
@@ -54,12 +51,9 @@ str_remove <- function(string, pattern) {
 #' @staticexport
 
 str_remove_all <- function(string, pattern) {
+	if (length(string) == 0 || length(pattern) == 0) return(character(0))
 	is_fixed <- inherits(pattern, "stringr_fixed")
-
-	string <- Vectorize(gsub, c("pattern", "x"), USE.NAMES = FALSE)(
+	Vectorize(gsub, c("pattern", "x"), USE.NAMES = FALSE)(
 		pattern, replacement = "", x = string, perl = !is_fixed, fixed = is_fixed
 	)
-
-	mode(string) <- "character"
-	string
 }

--- a/R/str_replace.R
+++ b/R/str_replace.R
@@ -33,14 +33,15 @@
 #' @staticexport
 
 str_replace <- function(string, pattern, replacement) {
+	if (length(string) == 0 || length(pattern) == 0 || length(replacement) == 0) {
+		return(character(0))
+	}
+
 	is_fixed <- inherits(pattern, "stringr_fixed")
 
-	string <- Vectorize(sub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
+	Vectorize(sub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
 		pattern, replacement, x = string, perl = !is_fixed, fixed = is_fixed
 	)
-
-	mode(string) <- "character"
-	string
 }
 
 #' Replace matched patterns in a string
@@ -94,12 +95,13 @@ str_replace_all <- function(string, pattern, replacement) {
 		return(string)
 	}
 
-	string <- Vectorize(gsub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
+	if (length(string) == 0 || length(pattern) == 0 || length(replacement) == 0) {
+		return(character(0))
+	}
+
+	Vectorize(gsub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
 		pattern, replacement, x = string, perl = !is_fixed, fixed = is_fixed
 	)
-
-	mode(string) <- "character"
-	string
 }
 
 #' Turn NA into "NA"

--- a/R/str_subset.R
+++ b/R/str_subset.R
@@ -23,6 +23,8 @@
 #' @staticexport
 
 str_subset <- function(string, pattern, negate = FALSE) {
+	if (length(string) == 0 || length(pattern) == 0) return(character(0))
+
 	ignore.case <- isTRUE(attr(pattern, "options")$case_insensitive)
 	is_fixed <- !ignore.case && inherits(pattern, "stringr_fixed")
 
@@ -68,6 +70,8 @@ str_subset <- function(string, pattern, negate = FALSE) {
 #' @staticexport
 
 str_which <- function(string, pattern, negate = FALSE) {
+	if (length(string) == 0 || length(pattern) == 0) return(integer(0))
+
 	ignore.case <- isTRUE(attr(pattern, "options")$case_insensitive)
 	is_fixed <- !ignore.case && inherits(pattern, "stringr_fixed")
 

--- a/inst/staticexports/str_count.R
+++ b/inst/staticexports/str_count.R
@@ -2,9 +2,9 @@
 # ======================================================================
 
 str_count <- function(string, pattern = "") {
+	if (length(string) == 0 || length(pattern) == 0) return(integer(0))
 	is_fixed <- inherits(pattern, "stringr_fixed")
-
-	count <- mapply(
+	mapply(
 		function(string, pattern) {
 			match <- unlist(
 				gregexpr(pattern, text = string, perl = !is_fixed, fixed = is_fixed)
@@ -13,7 +13,4 @@ str_count <- function(string, pattern = "") {
 		},
 		string, pattern, SIMPLIFY = "vector", USE.NAMES = FALSE
 	)
-
-	mode(count) <- "integer"
-	count
 }

--- a/inst/staticexports/str_remove.R
+++ b/inst/staticexports/str_remove.R
@@ -2,23 +2,17 @@
 # ======================================================================
 
 str_remove <- function(string, pattern) {
+	if (length(string) == 0 || length(pattern) == 0) return(character(0))
 	is_fixed <- inherits(pattern, "stringr_fixed")
-
-	string <- Vectorize(sub, c("pattern", "x"), USE.NAMES = FALSE)(
+	Vectorize(sub, c("pattern", "x"), USE.NAMES = FALSE)(
 		pattern, replacement = "", x = string, perl = !is_fixed, fixed = is_fixed
 	)
-
-	mode(string) <- "character"
-	string
 }
 
 str_remove_all <- function(string, pattern) {
+	if (length(string) == 0 || length(pattern) == 0) return(character(0))
 	is_fixed <- inherits(pattern, "stringr_fixed")
-
-	string <- Vectorize(gsub, c("pattern", "x"), USE.NAMES = FALSE)(
+	Vectorize(gsub, c("pattern", "x"), USE.NAMES = FALSE)(
 		pattern, replacement = "", x = string, perl = !is_fixed, fixed = is_fixed
 	)
-
-	mode(string) <- "character"
-	string
 }

--- a/inst/staticexports/str_replace.R
+++ b/inst/staticexports/str_replace.R
@@ -2,14 +2,15 @@
 # ======================================================================
 
 str_replace <- function(string, pattern, replacement) {
+	if (length(string) == 0 || length(pattern) == 0 || length(replacement) == 0) {
+		return(character(0))
+	}
+
 	is_fixed <- inherits(pattern, "stringr_fixed")
 
-	string <- Vectorize(sub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
+	Vectorize(sub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
 		pattern, replacement, x = string, perl = !is_fixed, fixed = is_fixed
 	)
-
-	mode(string) <- "character"
-	string
 }
 
 str_replace_all <- function(string, pattern, replacement) {
@@ -28,12 +29,13 @@ str_replace_all <- function(string, pattern, replacement) {
 		return(string)
 	}
 
-	string <- Vectorize(gsub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
+	if (length(string) == 0 || length(pattern) == 0 || length(replacement) == 0) {
+		return(character(0))
+	}
+
+	Vectorize(gsub, c("pattern", "replacement", "x"), USE.NAMES = FALSE)(
 		pattern, replacement, x = string, perl = !is_fixed, fixed = is_fixed
 	)
-
-	mode(string) <- "character"
-	string
 }
 
 str_replace_na <- function(string, replacement = "NA") {

--- a/inst/staticexports/str_subset.R
+++ b/inst/staticexports/str_subset.R
@@ -2,6 +2,8 @@
 # ======================================================================
 
 str_subset <- function(string, pattern, negate = FALSE) {
+	if (length(string) == 0 || length(pattern) == 0) return(character(0))
+
 	ignore.case <- isTRUE(attr(pattern, "options")$case_insensitive)
 	is_fixed <- !ignore.case && inherits(pattern, "stringr_fixed")
 
@@ -23,6 +25,8 @@ str_subset <- function(string, pattern, negate = FALSE) {
 }
 
 str_which <- function(string, pattern, negate = FALSE) {
+	if (length(string) == 0 || length(pattern) == 0) return(integer(0))
+
 	ignore.case <- isTRUE(attr(pattern, "options")$case_insensitive)
 	is_fixed <- !ignore.case && inherits(pattern, "stringr_fixed")
 

--- a/tests/testthat/test-str_c.R
+++ b/tests/testthat/test-str_c.R
@@ -1,4 +1,4 @@
-test_that("output is always character", {
+test_that("zero-length input", {
 	expect_equal(str_c(), character(0))
 })
 

--- a/tests/testthat/test-str_count.R
+++ b/tests/testthat/test-str_count.R
@@ -1,5 +1,9 @@
-test_that("output is always integer", {
+test_that("zero-length input", {
 	expect_equal(str_count(character(0), character(0)), integer(0))
+})
+
+test_that("mixed zero- and non-zero-length input", {
+	expect_equal(str_count(character(0), ""), integer(0))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_detect.R
+++ b/tests/testthat/test-str_detect.R
@@ -1,8 +1,15 @@
-test_that("output is always logical", {
+test_that("zero-length input", {
 	expect_equal(str_detect(character(0), character(0)), logical(0))
 	expect_equal(str_starts(character(0), character(0)), logical(0))
 	expect_equal(str_ends(character(0), character(0)), logical(0))
 })
+
+test_that("mixed zero- and non-zero-length input", {
+	expect_equal(str_detect(character(0), ""), logical(0))
+	expect_equal(str_starts(character(0), ""), logical(0))
+	expect_equal(str_ends(character(0), ""), logical(0))
+})
+
 
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr

--- a/tests/testthat/test-str_extract.R
+++ b/tests/testthat/test-str_extract.R
@@ -1,9 +1,11 @@
-test_that("output is always character", {
+test_that("zero-length input", {
 	expect_equal(str_extract(character(0), character(0)), character(0))
+	expect_equal(str_extract_all(character(0), character(0)), list())
 })
 
-test_that("output is always a list", {
-	expect_equal(str_extract_all(character(0), character(0)), list())
+test_that("mixed zero- and non-zero-length input", {
+	expect_equal(str_extract(character(0), ""), character(0))
+	expect_equal(str_extract_all(character(0), ""), list())
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_length.R
+++ b/tests/testthat/test-str_length.R
@@ -1,4 +1,4 @@
-test_that("output is always integer", {
+test_that("zero-length input", {
 	expect_equal(str_length(character(0)), integer(0))
 	expect_equal(str_width(character(0)), integer(0))
 })

--- a/tests/testthat/test-str_match.R
+++ b/tests/testthat/test-str_match.R
@@ -1,5 +1,9 @@
-test_that("output is always character", {
+test_that("zero-length input", {
 	expect_equal(str_match(character(0), character(0)), matrix(character(0)))
+})
+
+test_that("mixed zero- and non-zero-length input", {
+	expect_equal(str_match(character(0), ""), matrix(character(0)))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_pad.R
+++ b/tests/testthat/test-str_pad.R
@@ -1,4 +1,4 @@
-test_that("output is always character", {
+test_that("zero-length input", {
 	expect_equal(str_pad(character(0), 0), character(0))
 })
 

--- a/tests/testthat/test-str_remove.R
+++ b/tests/testthat/test-str_remove.R
@@ -1,6 +1,11 @@
-test_that("output is always character", {
+test_that("zero-length input", {
 	expect_equal(str_remove(character(0), character(0)), character(0))
 	expect_equal(str_remove_all(character(0), character(0)), character(0))
+})
+
+test_that("mixed zero- and non-zero-length input", {
+	expect_equal(str_remove(character(0), ""), character(0))
+	expect_equal(str_remove_all(character(0), ""), character(0))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_replace.R
+++ b/tests/testthat/test-str_replace.R
@@ -1,4 +1,4 @@
-test_that("output is always character", {
+test_that("zero-length input", {
 	expect_equal(
 		str_replace(character(0), character(0), character(0)),
 		character(0)
@@ -11,6 +11,12 @@ test_that("output is always character", {
 		str_replace_na(character(0), character(0)),
 		character(0)
 	)
+})
+
+test_that("mixed zero- and non-zero-length input", {
+	expect_equal(str_replace(character(0), "", ""), character(0))
+	expect_equal(str_replace_all(character(0), "", ""), character(0))
+	expect_equal(str_replace_na(character(0), ""), character(0))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_split.R
+++ b/tests/testthat/test-str_split.R
@@ -1,10 +1,15 @@
-test_that("output is always a list", {
+test_that("zero-length input", {
 	expect_equal(str_split(character(0), character(0)), list())
-})
-
-test_that("output is always a character matrix", {
 	expect_equal(
 		str_split_fixed(character(0), character(0), 1),
+		matrix(character(0))
+	)
+})
+
+test_that("mixed zero- and non-zero-length input", {
+	expect_equal(str_split(character(0), ""), list())
+	expect_equal(
+		str_split_fixed(character(0), "", 1),
 		matrix(character(0))
 	)
 })

--- a/tests/testthat/test-str_subset.R
+++ b/tests/testthat/test-str_subset.R
@@ -1,9 +1,11 @@
-test_that("output is always character", {
+test_that("zero-length input", {
 	expect_equal(str_subset(character(0), character(0)), character(0))
+	expect_equal(str_which(character(0), character(0)), integer(0))
 })
 
-test_that("output is always integer", {
-	expect_equal(str_which(character(0), character(0)), integer(0))
+test_that("mixed zero- and non-zero-length input", {
+	expect_equal(str_subset(character(0), ""), character(0))
+	expect_equal(str_which(character(0), ""), integer(0))
 })
 
 # These tests are adapted from tests in the stringr package

--- a/tests/testthat/test-str_trim.R
+++ b/tests/testthat/test-str_trim.R
@@ -1,4 +1,4 @@
-test_that("output is always character", {
+test_that("zero-length input", {
 	expect_equal(str_trim(character(0)), character(0))
 	expect_equal(str_squish(character(0)), character(0))
 })


### PR DESCRIPTION
In R < 4.2, mixed zero- and non-zero-length inputs to `Vectorize()`, `Map()` and `mapply()` produce an error. Early returns ensure their results are consistent with `stringr`.