### PR TITLE
`str_split()` can now return results with trailing `""`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: stringstatic
 Title: Dependency-Free String Operations
-Version: 0.1.0.9000
+Version: 0.1.1
 Authors@R: c(
     person("Alexander", "Rossell Hayes", , "alexander@rossellhayes.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-9412-0457")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# stringstatic (development version)
+# stringstatic 0.1.1
 
 # stringstatic 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # stringstatic 0.1.1
 
+* `str_split()` and `str_split_fixed()` now return a result with a trailing empty string (`""`) when the end of `string` matches `pattern`. This matches the behavior of `stringr::str_split()` and differs from `base::strsplit()` (#16).
+
 # stringstatic 0.1.0
 
 ## New functions

--- a/R/str_split.R
+++ b/R/str_split.R
@@ -50,9 +50,23 @@ str_split <- function(string, pattern, n = Inf, simplify = FALSE) {
 	result <- Map(
 		function(string, pattern) {
 			if (is.na(string) || is.na(pattern)) return(NA_character_)
-			unlist(
-				strsplit(string, split = pattern, fixed = is_fixed, perl = !is_fixed)
+
+			split <- strsplit(
+				string,
+				split = pattern,
+				fixed = is_fixed,
+				perl = !is_fixed
 			)
+
+			split[lengths(split) == 0] <- ""
+			split <- unlist(split)
+
+			match <- gregexpr(pattern, string, perl = !is_fixed, fixed = is_fixed)[[1]]
+			match_ends <- match + attr(match, "match.length")
+			match_at_end_of_string <- any(match_ends > nchar(string))
+			if (match_at_end_of_string) return(c(split[match_at_end_of_string], ""))
+
+			split
 		},
 		string, pattern, USE.NAMES = FALSE
 	)
@@ -119,9 +133,23 @@ str_split_fixed <- function(string, pattern, n) {
 	result <- Map(
 		function(string, pattern) {
 			if (is.na(string) || is.na(pattern)) return(NA_character_)
-			unlist(
-				strsplit(string, split = pattern, fixed = is_fixed, perl = !is_fixed)
+
+			split <- strsplit(
+				string,
+				split = pattern,
+				fixed = is_fixed,
+				perl = !is_fixed
 			)
+
+			split[lengths(split) == 0] <- ""
+			split <- unlist(split)
+
+			match <- gregexpr(pattern, string, perl = !is_fixed, fixed = is_fixed)[[1]]
+			match_ends <- match + attr(match, "match.length")
+			match_at_end_of_string <- any(match_ends > nchar(string))
+			if (match_at_end_of_string) return(c(split[match_at_end_of_string], ""))
+
+			split
 		},
 		string, pattern, USE.NAMES = FALSE
 	)

--- a/tests/testthat/test-str_split.R
+++ b/tests/testthat/test-str_split.R
@@ -14,6 +14,18 @@ test_that("mixed zero- and non-zero-length input", {
 	)
 })
 
+test_that("input starts and ends with a match", {
+	expect_equal(
+		str_split("-123-456-789-", "-"),
+		list(c("", "123", "456", "789", ""))
+	)
+
+	expect_equal(
+		str_split_fixed("-123-456-789-", "-", Inf),
+		matrix(c("", "123", "456", "789", ""), nrow = 1)
+	)
+})
+
 # These tests are adapted from tests in the stringr package
 # https://github.com/tidyverse/stringr
 #


### PR DESCRIPTION
`str_split()` and `str_split_fixed()` now return a result with a trailing empty string (`""`) when the end of `string` matches `pattern`. This matches the behavior of `stringr::str_split()` and differs from `base::strsplit()`.

``` r
base::strsplit("-123-456-789-", "-")
#> [[1]]
#> [1] ""    "123" "456" "789"

stringr::str_split("-123-456-789-", "-")
#> [[1]]
#> [1] ""    "123" "456" "789" ""

stringstatic::str_split("-123-456-789-", "-")
#> [[1]]
#> [1] ""    "123" "456" "789" ""
```

<sup>Created on 2023-05-12 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>